### PR TITLE
Fix setting of LDFLAGS on macOS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       name: "macOS with vanilla Clang"
       osx_image: xcode10.2
       env:
-        - MATRIX_EVAL="export LDFLAGS="$LDFLAGS -L/usr/local/opt/llvm/lib" && export CPPFLAGS="$CPPFLAGS -I/usr/local/opt/llvm/include" && CC=/usr/local/opt/llvm/bin/clang && CXX=/usr/local/opt/llvm/bin/clang++"
+        - MATRIX_EVAL="CC=/usr/local/opt/llvm/bin/clang && CXX=/usr/local/opt/llvm/bin/clang++"
       addons:
         homebrew:
           packages:
@@ -52,6 +52,10 @@ before_install:
 
 # set up installation
 install:
+  - |
+    if [[ "${TRAVIS_JOB_NAME}" = macOS*Clang ]]; then
+      export LDFLAGS="${LDFLAGS} -L$(brew --prefix libomp)/lib"
+    fi
   - echo $LDFLAGS
   - echo $CPPFLAGS
   - mkdir build


### PR DESCRIPTION
There was a problem with nested quotes.  One possibility was just to escape the inner quotes.  However I think it's good to set it also for the other Clang job, so the easiest thing is to directly set `LDFLAGS` as needed in the `install` stage.  `CPPFLAGS` shouldn't be needed (BTW, I think `cmake` expects [`CXXFLAGS`](https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html), I'm not sure `CPPFLAGS` will be read).